### PR TITLE
Adding isInvoiceSeparate to subscription

### DIFF
--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "active_zuora"
-  s.version = "1.4.18"
+  s.version = "1.4.19"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/lib/zuora/ZUORA.rb
+++ b/lib/zuora/ZUORA.rb
@@ -914,7 +914,6 @@ class Subscription < ZObject
   attr_accessor :contractAcceptanceDate
   attr_accessor :contractEffectiveDate
   attr_accessor :initialTerm
-  attr_accessor :isInvoiceSeparate
   attr_accessor :name
   attr_accessor :notes
   attr_accessor :originalId
@@ -927,8 +926,9 @@ class Subscription < ZObject
   attr_accessor :termEndDate
   attr_accessor :termType
   attr_accessor :version
+  attr_accessor :isInvoiceSeparate
 
-  def initialize(fieldsToNull = [], id = nil, accountId = nil, autoRenew = nil, cancelledDate = nil, createdDate = nil, contractAcceptanceDate = nil, contractEffectiveDate = nil, initialTerm = nil, isInvoiceSeparate = nil, name = nil, notes = nil, originalId = nil, previousSubscriptionId = nil, renewalTerm = nil, serviceActivationDate = nil, subscriptionEndDate = nil, status = nil, termStartDate = nil, termEndDate = nil, termType = nil, version = nil)
+  def initialize(fieldsToNull = [], id = nil, accountId = nil, autoRenew = nil, cancelledDate = nil, createdDate = nil, contractAcceptanceDate = nil, contractEffectiveDate = nil, initialTerm = nil, name = nil, notes = nil, originalId = nil, previousSubscriptionId = nil, renewalTerm = nil, serviceActivationDate = nil, subscriptionEndDate = nil, status = nil, termStartDate = nil, termEndDate = nil, termType = nil, version = nil, isInvoiceSeparate = nil)
     @fieldsToNull = fieldsToNull
     @id = id
     @accountId = accountId
@@ -938,7 +938,6 @@ class Subscription < ZObject
     @contractAcceptanceDate = contractAcceptanceDate
     @contractEffectiveDate = contractEffectiveDate
     @initialTerm = initialTerm
-    @isInvoiceSeparate = isInvoiceSeparate
     @name = name
     @notes = notes
     @originalId = originalId
@@ -951,6 +950,7 @@ class Subscription < ZObject
     @termEndDate = termEndDate
     @termType = termType
     @version = version
+    @isInvoiceSeparate = isInvoiceSeparate
   end
 end
 

--- a/lib/zuora/ZUORA.rb
+++ b/lib/zuora/ZUORA.rb
@@ -914,6 +914,7 @@ class Subscription < ZObject
   attr_accessor :contractAcceptanceDate
   attr_accessor :contractEffectiveDate
   attr_accessor :initialTerm
+  attr_accessor :isInvoiceSeparate
   attr_accessor :name
   attr_accessor :notes
   attr_accessor :originalId
@@ -927,7 +928,7 @@ class Subscription < ZObject
   attr_accessor :termType
   attr_accessor :version
 
-  def initialize(fieldsToNull = [], id = nil, accountId = nil, autoRenew = nil, cancelledDate = nil, createdDate = nil, contractAcceptanceDate = nil, contractEffectiveDate = nil, initialTerm = nil, name = nil, notes = nil, originalId = nil, previousSubscriptionId = nil, renewalTerm = nil, serviceActivationDate = nil, subscriptionEndDate = nil, status = nil, termStartDate = nil, termEndDate = nil, termType = nil, version = nil)
+  def initialize(fieldsToNull = [], id = nil, accountId = nil, autoRenew = nil, cancelledDate = nil, createdDate = nil, contractAcceptanceDate = nil, contractEffectiveDate = nil, initialTerm = nil, isInvoiceSeparate = nil, name = nil, notes = nil, originalId = nil, previousSubscriptionId = nil, renewalTerm = nil, serviceActivationDate = nil, subscriptionEndDate = nil, status = nil, termStartDate = nil, termEndDate = nil, termType = nil, version = nil)
     @fieldsToNull = fieldsToNull
     @id = id
     @accountId = accountId
@@ -937,6 +938,7 @@ class Subscription < ZObject
     @contractAcceptanceDate = contractAcceptanceDate
     @contractEffectiveDate = contractEffectiveDate
     @initialTerm = initialTerm
+    @isInvoiceSeparate = isInvoiceSeparate
     @name = name
     @notes = notes
     @originalId = originalId
@@ -1151,7 +1153,7 @@ class AmendOptions
   attr_accessor :generateInvoice, :invoiceProcessingOptions, :processPayments
 
   def initialize(generateInvoice = nil, invoiceProcessingOptions = nil, processPayments = nil)
-    @generateInvoice, @invoiceProcessingOptions, @processPayments = 
+    @generateInvoice, @invoiceProcessingOptions, @processPayments =
       generateInvoice, invoiceProcessingOptions, processPayments
   end
 end

--- a/lib/zuora/ZUORAMappingRegistry.rb
+++ b/lib/zuora/ZUORAMappingRegistry.rb
@@ -453,7 +453,8 @@ module DefaultMappingRegistry
       ["status", ["SOAP::SOAPString", XSD::QName.new(NsObjectApiZuoraCom, "Status")], [0, 1]],
       ["termStartDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermStartDate")], [0, 1]],
       ["termEndDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermEndDate")], [0, 1]],
-      ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]]
+      ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]],
+      ["isInvoiceSeparate", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
     ]
   )
 
@@ -1182,7 +1183,8 @@ module DefaultMappingRegistry
       ["termStartDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermStartDate")], [0, 1]],
       ["termEndDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermEndDate")], [0, 1]],
       ["termType", ["SOAP::SOAPString", XSD::QName.new(NsObjectApiZuoraCom, "TermType")], [0, 1]],
-      ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]]
+      ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]],
+      ["isInvoiceSeparate", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
     ]
   )
 

--- a/lib/zuora/ZUORAMappingRegistry.rb
+++ b/lib/zuora/ZUORAMappingRegistry.rb
@@ -454,7 +454,7 @@ module DefaultMappingRegistry
       ["termStartDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermStartDate")], [0, 1]],
       ["termEndDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermEndDate")], [0, 1]],
       ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]],
-      ["isInvoiceSeparate", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
+      ["isInvoiceSeparate", ["SOAP::SOAPBoolean", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
     ]
   )
 
@@ -1184,7 +1184,7 @@ module DefaultMappingRegistry
       ["termEndDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsObjectApiZuoraCom, "TermEndDate")], [0, 1]],
       ["termType", ["SOAP::SOAPString", XSD::QName.new(NsObjectApiZuoraCom, "TermType")], [0, 1]],
       ["version", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "Version")], [0, 1]],
-      ["isInvoiceSeparate", ["SOAP::SOAPInt", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
+      ["isInvoiceSeparate", ["SOAP::SOAPBoolean", XSD::QName.new(NsObjectApiZuoraCom, "IsInvoiceSeparate")], [0, 1]]
     ]
   )
 


### PR DESCRIPTION
Adding isInvoiceSeparate to the subscription object.
Easy QA. Pull this branch, run this code.
Open a console
`Zuora::Subscription.update_attributes(:id => "2c92c0f94b34f993014b3c95fc8651a5", :isInvoiceSeparate => "true")`
Check to see if it sticks
`Zuora::Subscription.find("2c92c0f94b34f993014b3c95fc8651a5")`
`Zuora::Subscription.update_attributes(:id => "2c92c0f94b34f993014b3c95fc8651a5", :isInvoiceSeparate => "false")`